### PR TITLE
Add ability to free-form search youtube results

### DIFF
--- a/utils/helpers/youtubei/youtubeiExtractor.js
+++ b/utils/helpers/youtubei/youtubeiExtractor.js
@@ -160,8 +160,23 @@ class YoutubeSabrExtractor extends BaseExtractor {
                 return this.createResponse(dpPlaylist, plTracks);
             }
 
+            async function searchYoutubeWithQueryString(query) {
+                const search = await this.innertube.search(query);
+                if (search.results.length === 0) return;
+
+                return search.results[0];
+            };
+
             // Otherwise treat as single video
-            const videoId = extractVideoId(query);
+            let videoId = null;
+            try {
+                videoId = extractVideoId(query);
+            } catch (err) {
+                if (err.message === "Invalid youtube url") {
+                    const searchResult = await searchYoutubeWithQueryString(query);
+                    videoId = searchResult.video_id;
+                }
+            }
             if (!videoId) return this.createResponse(null, []);
 
             const info = await this.innertube.getBasicInfo(videoId);


### PR DESCRIPTION
When testing YouTube free-form search in my own bot, I consistently encountered the error "Invalid YouTube URL".
This change fixes that issue by searching on YouTube instead of requiring a direct YouTube link.